### PR TITLE
Texte in allen Sprachen korrigiert.

### DIFF
--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -11,8 +11,8 @@
     "contact": "Kontakt",
     "website": "Hjemmeside",
     "email": "Email",
-    "www": "www.kulturfinder.sh",
-    "link": "kulturfinder.sh",
+    "www": "www.kulturfinder.bremen.de",
+    "link": "kulturfinder.bremen.de",
     "mailto": "info@kultursphaere.sh",
     "favorites": "Bogmærker",
     "filters": "Filtrene",
@@ -38,10 +38,10 @@
     "loading": "Belaster kultur..."
   },
   "SEO":{
-    "title": "kulturfinder.sh",
-    "dashboardTitle": "kulturfinder.sh - Kultur i din hånd",
-    "description": "The kulturfinder.sh app has all the information about culture in Schleswig-Holstein that you need. With more than 300 cultural institutions featured, you can have a look into descriptions, opening-times or digital services of each institution.",
-    "commonKeywords": "Kulturfinder, culture, app, Schleswig-Holstein, Kultursphäre, digital, Living Images, kulturfinder.sh, cultural institutions"
+    "title": "kulturfinder.bremen.de",
+    "dashboardTitle": "kulturfinder.bremen.de - Kultur i din hånd",
+    "description": "The kulturfinder.bremen.de app has all the information about culture in Bremen that you need. With more than 300 cultural institutions featured, you can have a look into descriptions, opening-times or digital services of each institution.",
+    "commonKeywords": "Kulturfinder, culture, app, Bremen, Kultursphäre, digital, Living Images, kulturfinder.bremen.de, cultural institutions"
   },
   "locales": {
     "de": {
@@ -56,7 +56,7 @@
   },
   "navbar": {
     "aboutUs": "Om os",
-    "logo": "kulturfinder.sh-logo",
+    "logo": "kulturfinder.bremen.de-logo",
     "settings": "Indstillinger",
     "saveAsFavorite": "Gem som bogmærke",
     "start": "Start",
@@ -143,7 +143,7 @@
     "positionRelatedDataProcessing": "I forbindelse med denne app er det muligt at bestemme brugerens geografiske position, såfremt brugeren har givet tilladelse til det i indstillingerne på sin terminal. Til positionsbestemmelsen anvendes en række teknologier, som f. eks. IP-adresse og GPS-data. Disse data anvendes udelukkende på brugerens terminal.",
     "accessibility": {
       "declarationsHeadline": "Erklärung zur Barrierefreiheit",
-      "LBGG_BITV": "Das Team des kulturfinder.sh bemüht sich, die Website kulturfinder.sh im Einklang mit dem Gesetz zur Gleichstellung von Menschen mit Behinderung in Schleswig Holstein (LBGG) und der Barrierefreie-Informationstechnik-Verordnung (BITV) barrierefrei zugänglich zu machen. Diese Erklärung zur Barrierefreiheit gilt für den gesamten Internetauftritt kulturfinder.sh",
+      "LBGG_BITV": "Das Team des kulturfinder.bremen.de bemüht sich, die Website kulturfinder.bremen.de im Einklang mit dem Gesetz zur Gleichstellung von Menschen mit Behinderung in Schleswig Holstein (LBGG) und der Barrierefreie-Informationstechnik-Verordnung (BITV) barrierefrei zugänglich zu machen. Diese Erklärung zur Barrierefreiheit gilt für den gesamten Internetauftritt kulturfinder.bremen.de",
       "currentStatusHeadline": "Stand der Vereinbarkeit mit den Anforderungen",
       "currentStatus": "Die Website ist mit der BITV teilweise vereinbar. Die „gute Zugänglichkeit“ ist sichergestellt.\nBei folgenden Inhalten wurden beim Barrierefreiheitstest Mängel festgestellt und sind nicht vereinbar mit den genannten Rechtsvorschriften:",
       "faults": {
@@ -178,7 +178,7 @@
     "choice": "Udvalgt licens"
   },
   "noData": {
-    "welcome": "Willkommen beim kulturfinder.sh!",
+    "welcome": "Willkommen beim kulturfinder.bremen.de!",
     "notDownloadable": "Leider konnten wir notwendige Daten nicht von unserem Kooperationspartner herunterladen. Bitte haben Sie ein wenig Geduld, es wird bereits an einer Lösung gearbeitet.",
     "reload": "Erneut laden"
   },
@@ -208,7 +208,7 @@
       "step2": "2. Click on the blue button."
     },
     "mac": {
-      "step1": "1. Open the menu and click on 'install kulturfinder.sh...' or directly click on the plus icon in the address bar.",
+      "step1": "1. Open the menu and click on 'install kulturfinder.bremen.de...' or directly click on the plus icon in the address bar.",
       "step2": "2. Click on the blue button."
     }
   },
@@ -220,7 +220,7 @@
     "benefit2": "Afstand til alle destinationer",
     "enableGPS": "GPS aktivere",
     "howToHandle": "Your location for this site is blocked.",
-    "howToHandle2" : "Please check the settings of your device and refresh this website, to use the location functions of kulturfinder.sh"
+    "howToHandle2" : "Please check the settings of your device and refresh this website, to use the location functions of kulturfinder.bremen.de"
   },
   "noNetwork": {
     "title": "No internet connection",
@@ -307,7 +307,7 @@
       "sd0025": "Reformationsdag (31. oktober)"
     },
     "feedback": "Feedback",
-    "feedbackIntro": "Any comments, ideas, or feedback about the app? Please contact our team at kulturfinder.sh. We would very much appreciate to hear from you!",
+    "feedbackIntro": "Any comments, ideas, or feedback about the app? Please contact our team at kulturfinder.bremen.de. We would very much appreciate to hear from you!",
     "feedbackInstitutionHeadline": "Would you like to contact the institution directly?",
     "feedbackInstitutionText": "For questions or inqueries concerning the institution, please check out the 'contact' section for each institution.",
     "feedbackWrongOpeningHoursHeadline": "Åbningstider forkerte?",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -11,8 +11,8 @@
     "contact": "Kontakt",
     "website": "Webseite",
     "email": "Email",
-    "www": "www.kulturfinder.sh",
-    "link": "kulturfinder.sh",
+    "www": "www.kulturfinder.bremen.de",
+    "link": "kulturfinder.bremen.de",
     "mailto": "info@kultursphaere.sh",
     "favorites": "Favoriten",
     "filters": "Filter",
@@ -38,10 +38,10 @@
     "loading": "Lädt Kultur..."
   },
   "SEO":{
-    "title": "kulturfinder.sh",
-    "dashboardTitle": "kulturfinder.sh - Kultur in deiner Hand",
-    "description": "Der kulturfinder.sh ist eine neue App, die es den Nutzer:innen ermöglicht, mobil auf ihrem Smartphone Kulturinstitutionen in ganz Schleswig-Holstein zu finden. Geobasiert werden Kultureinrichtungen im Umkreis des Standortes des Nutzers auf einer Landkarte angezeigt. Zu jeder Institution gibt es zudem ein Foto sowie eine Beschreibung, die Adresse und weitere Angebote.",
-    "commonKeywords": "Kulturfinder, Kultur, App, Schleswig-Holstein, Kultursphäre, Digitalisierung, Living Images, Schietwetter, kulturfinder.sh, Kulturinstitution"
+    "title": "kulturfinder.bremen.de",
+    "dashboardTitle": "kulturfinder.bremen.de - Kultur in deiner Hand",
+    "description": "Der kulturfinder.bremen.de ist eine neue App, die es den Nutzer:innen ermöglicht, mobil auf ihrem Smartphone Kulturinstitutionen in ganz Bremen zu finden. Geobasiert werden Kultureinrichtungen im Umkreis des Standortes des Nutzers auf einer Landkarte angezeigt. Zu jeder Institution gibt es zudem ein Foto sowie eine Beschreibung, die Adresse und weitere Angebote.",
+    "commonKeywords": "Kulturfinder, Kultur, App, Bremen, Kultursphäre, Digitalisierung, Living Images, Schietwetter, kulturfinder.bremen.de, Kulturinstitution"
   },
   "locales": {
     "de": {
@@ -144,7 +144,7 @@
     "positionRelatedDataProcessing": "Innerhalb der App ist es möglich Ihren Standort bestimmen zu lassen, wenn sie dies in den Einstellungen ihres Endgerätes zugelassen haben. Für die Standortbestimmung werden verschiedene Technologien verwendet, wie bspw. IP-Adresse und GPS Daten. Diese Daten werden ausschließlich auf Ihrem Endgerät verarbeitet.",
     "accessibility": {
       "declarationsHeadline": "Erklärung zur Barrierefreiheit",
-      "LBGG_BITV": "Das Team des kulturfinder.sh bemüht sich, die Website kulturfinder.sh im Einklang mit dem Gesetz zur Gleichstellung von Menschen mit Behinderung in Schleswig Holstein (LBGG) und der Barrierefreie-Informationstechnik-Verordnung (BITV) barrierefrei zugänglich zu machen. Diese Erklärung zur Barrierefreiheit gilt für den gesamten Internetauftritt kulturfinder.sh",
+      "LBGG_BITV": "Das Team des kulturfinder.bremen.de bemüht sich, die Website kulturfinder.bremen.de im Einklang mit dem Gesetz zur Gleichstellung von Menschen mit Behinderung in Schleswig Holstein (LBGG) und der Barrierefreie-Informationstechnik-Verordnung (BITV) barrierefrei zugänglich zu machen. Diese Erklärung zur Barrierefreiheit gilt für den gesamten Internetauftritt kulturfinder.bremen.de",
       "currentStatusHeadline": "Stand der Vereinbarkeit mit den Anforderungen",
       "currentStatus": "Die Website ist mit der BITV teilweise vereinbar. Die „gute Zugänglichkeit“ ist sichergestellt.\nBei folgenden Inhalten wurden beim Barrierefreiheitstest Mängel festgestellt und sind nicht vereinbar mit den genannten Rechtsvorschriften:",
       "faults": {
@@ -179,7 +179,7 @@
     "choice": "Gewählte Lizenz"
   },
   "noData": {
-    "welcome": "Willkommen beim kulturfinder.sh!",
+    "welcome": "Willkommen beim kulturfinder.bremen.de!",
     "notDownloadable": "Leider konnten wir notwendige Daten nicht von unserem Kooperationspartner herunterladen. Bitte haben Sie ein wenig Geduld, es wird bereits an einer Lösung gearbeitet.",
     "reload": "Erneut laden"
   },
@@ -208,7 +208,7 @@
       "step2": "2. Abschließend klicken Sie auf die blaue Schaltfläche."
     },
     "mac": {
-      "step1": "1. Öffnen Sie das Menü und klicken auf 'kulturfinder.sh installieren...' oder klicken Sie direkt auf das Plus-Symbol in der Adresszeile.",
+      "step1": "1. Öffnen Sie das Menü und klicken auf 'kulturfinder.bremen.de installieren...' oder klicken Sie direkt auf das Plus-Symbol in der Adresszeile.",
       "step2": "2. Abschließend klicken Sie auf die blaue Schaltfläche."
     }
   },
@@ -220,7 +220,7 @@
     "benefit2": "Entfernung zu allen Zielen",
     "enableGPS": "GPS aktivieren",
     "howToHandle": "Ihre Geräteeinstellungen blockieren den Zugriff auf ihren GPS-Standort.",
-    "howToHandle2" : "Prüfen sie die Einstellungen ihres Gerätes und aktualisieren sie die Website, um die Standortfunktion vom kulturfinder.sh nutzen zu können."
+    "howToHandle2" : "Prüfen sie die Einstellungen ihres Gerätes und aktualisieren sie die Website, um die Standortfunktion vom kulturfinder.bremen.de nutzen zu können."
   },
   "noNetwork": {
     "title": "Kein Internet",
@@ -249,7 +249,7 @@
     "noDescription": "Es tut uns leid. Zu dieser Institution fehlt die Beschreibung. Wir arbeiten dran.",
     "favorite": "Favorit",
     "share": "Teilen",
-    "shareSubject": "Schau einmal, was ich für dich in der kulturfinder.sh-App gefunden habe:",
+    "shareSubject": "Schau einmal, was ich für dich in der kulturfinder.bremen.de-App gefunden habe:",
     "showOnMap": "Auf Karte anzeigen",
     "routeViaNavigationApp": "Anfahrt in Karten-Anwendung öffnen",
     "socialMedia": "Soziale Netzwerke",
@@ -306,7 +306,7 @@
       "sd0025": "Reformationstag"
     },
     "feedback": "Feedback",
-    "feedbackIntro": "Haben Sie Wünsche oder Kritik? Melden Sie sich gerne beim Team vom kulturfinder.sh. Wir freuen uns über Feedback!",
+    "feedbackIntro": "Haben Sie Wünsche oder Kritik? Melden Sie sich gerne beim Team vom kulturfinder.bremen.de. Wir freuen uns über Feedback!",
     "feedbackInstitutionHeadline": "Sie möchten direkt mit einer Institution in Kontakt treten?",
     "feedbackInstitutionText": "Melden sie sich bei Anliegen und Fragen bitte direkt bei der Institution. Informationen hierzu finden sie unter 'Kontakt' auf der Seite der Institution.",
     "feedbackWrongOpeningHoursHeadline": "Öffnungszeiten falsch?",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,8 +11,8 @@
     "contact": "Contact",
     "website": "Website",
     "email": "Email",
-    "www": "www.kulturfinder.sh",
-    "link": "kulturfinder.sh",
+    "www": "www.kulturfinder.bremen.de",
+    "link": "kulturfinder.bremen.de",
     "mailto": "info@kultursphaere.sh",
     "favorites": "Favorites",
     "filters": "Filters",
@@ -38,10 +38,10 @@
     "loading": "Loading culture..."
   },
   "SEO":{
-    "title": "kulturfinder.sh",
-    "dashboardTitle": "kulturfinder.sh - Culture in Your Hands",
-    "description": "The kulturfinder.sh is a new app that enables users to find cultural institutions in Schleswig-Holstein on their mobile devices. It uses to geodata to show users a map of nearby insitutions. A photo and description are included for  each institution as well as the address and information about other services.",
-    "commonKeywords": "Kulturfinder, culture, app, Schleswig-Holstein, Kultursphäre, digital, digitisation, Living Images, kulturfinder.sh, cultural institution"
+    "title": "kulturfinder.bremen.de",
+    "dashboardTitle": "kulturfinder.bremen.de - Culture in Your Hands",
+    "description": "The kulturfinder.bremen.de is a new app that enables users to find cultural institutions in Bremen on their mobile devices. It uses to geodata to show users a map of nearby insitutions. A photo and description are included for  each institution as well as the address and information about other services.",
+    "commonKeywords": "Kulturfinder, culture, app, Bremen, Kultursphäre, digital, digitisation, Living Images, kulturfinder.bremen.de, cultural institution"
   },
   "locales": {
     "de": {
@@ -56,7 +56,7 @@
   },
   "navbar": {
     "aboutUs": "About us",
-    "logo": "Logo of kulturfinder.sh",
+    "logo": "Logo of kulturfinder.bremen.de",
     "settings": "Settings",
     "saveAsFavorite": "Save as favourite",
     "start": "Start",
@@ -143,7 +143,7 @@
     "positionRelatedDataProcessing": "When in use, the app can access your location if you have granted it permission to do so in your device’s settings. Different technology is used to determine a person's location, e.g. IP address or GPS data. This data is processed exclusively on your device.",
     "accessibility": {
       "declarationsHeadline": "Accessibility statement",
-      "LBGG_BITV": "The kulturfinder.sh team makes every effort to ensure that the kulturfinder.sh website is accessible to everyone in compliance with the Act on Equal Treatment for people with disabilities in Schleswig-Holstein (LBGG) and the Barrier-Free Informational Technology Ordinance (BITV). This accessibility statement applies to the entire web presence of kulturfinder.sh.",
+      "LBGG_BITV": "The kulturfinder.bremen.de team makes every effort to ensure that the kulturfinder.bremen.de website is accessible to everyone in compliance with the Act on Equal Treatment for people with disabilities in Schleswig-Holstein (LBGG) and the Barrier-Free Informational Technology Ordinance (BITV). This accessibility statement applies to the entire web presence of kulturfinder.bremen.de.",
       "currentStatusHeadline": "Status of compliance with requirements",
       "currentStatus": "The website is partially compliant with the BITV. “Good accessibility” is guaranteed. Deficiencies were found in the accessibility of the following areas; these deficiencies are not compatible with the legal guidelines:",
       "faults": {
@@ -178,7 +178,7 @@
     "choice": "Selected licence"
   },
   "noData": {
-    "welcome": "Welcome to kulturfinder.sh!",
+    "welcome": "Welcome to kulturfinder.bremen.de!",
     "notDownloadable": "Unfortunately, our database is currently offline. We would kindly ask for your patience. Please try again later. We're working on it!",
     "reload": "Reload"
   },
@@ -208,7 +208,7 @@
       "step2": "2. Then click on the blue button."
     },
     "mac": {
-      "step1": "1. Open the menu and click on 'Install kulturfinder.sh...' or click on the plus icon on the address bar..",
+      "step1": "1. Open the menu and click on 'Install kulturfinder.bremen.de...' or click on the plus icon on the address bar..",
       "step2": "2. Then click on the blue button."
     }
   },
@@ -220,7 +220,7 @@
     "benefit2": "Distance to all destinations",
     "enableGPS": "Enable GPS",
     "howToHandle": "Location services are not enabled on your device.",
-    "howToHandle2" : "Please check your device settings and refresh this website to use the location services on kulturfinder.sh."
+    "howToHandle2" : "Please check your device settings and refresh this website to use the location services on kulturfinder.bremen.de."
   },
   "noNetwork": {
     "title": "No internet connection",
@@ -250,7 +250,7 @@
     "noDescription": "We're sorry. The description is not available in all languages yet. We're working on it.",
     "favorite": "Favorite",
     "share": "Share",
-    "shareSubject": "Check out what I have found for you in the culture finder app kulturfinder.sh:",
+    "shareSubject": "Check out what I have found for you in the culture finder app kulturfinder.bremen.de:",
     "showOnMap": "Display on map",
     "routeViaNavigationApp": "Show route in the map application",
     "socialMedia": "Social networks",
@@ -307,7 +307,7 @@
       "sd0025": "Reformation Day"
     },
     "feedback": "Feedback",
-    "feedbackIntro": "Have you got any comments or feedback about the app? Please contact our team at kulturfinder.sh. We look forward to hearing from you!",
+    "feedbackIntro": "Have you got any comments or feedback about the app? Please contact our team at kulturfinder.bremen.de. We look forward to hearing from you!",
     "feedbackInstitutionHeadline": "Would you like to contact the institution directly?",
     "feedbackInstitutionText": "For questions or enquiries, please contact the institution. You will find the details in the 'contact' section on the institution's page.",
     "feedbackWrongOpeningHoursHeadline": "Wrong opening hours?",


### PR DESCRIPTION
An allen Stellen wo es sinnvoll erschien "kulturfinder.sh" zu "Kulturfinder.bremen.de" und "Schleswig-Holstein" zu "Bremen" geändert.